### PR TITLE
Gracefully disable optional features on bad config

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -34,7 +34,9 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
 
         // Discord Notifier initialisieren
         discordNotifier = new DiscordNotifier(this);
-        discordNotifier.initialize();
+        if (!discordNotifier.initialize()) {
+            discordNotifier = null;
+        }
 
         // Datenbankkonfiguration aus config.yml laden
         String host = getConfig().getString("database.host");
@@ -43,6 +45,14 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         String username = getConfig().getString("database.username");
         String password = getConfig().getString("database.password");
 
+        // Prüfen, ob alle Daten vorhanden sind
+        if (host == null || host.isBlank() || database == null || database.isBlank()
+                || username == null || username.isBlank() || password == null || password.isBlank()) {
+            getLogger().severe("Ungültige Datenbankkonfiguration. Plugin wird deaktiviert.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
         // Datenbankverbindung und Repository initialisieren
         databaseManager = new DatabaseManager(host, port, database, username, password);
         try {
@@ -50,8 +60,9 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
             reportRepository = new ReportRepository(databaseManager, getLogger());
             getLogger().info("Datenbank erfolgreich verbunden.");
         } catch (SQLException e) {
-            getLogger().severe("Datenbankverbindung konnte nicht hergestellt werden!");
+            getLogger().severe("Datenbankverbindung konnte nicht hergestellt werden! Plugin wird deaktiviert.");
             e.printStackTrace();
+            getServer().getPluginManager().disablePlugin(this);
             return;
         }
 

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
@@ -20,12 +20,24 @@ public class DiscordNotifier {
         this.channelIdNotification = plugin.getConfig().getString("discord-channel-id-notifications");
     }
 
-    public void initialize() {
+    /**
+     * Initialisiert den Discord-Bot.
+     *
+     * @return true, wenn der Bot erfolgreich gestartet wurde, sonst false
+     */
+    public boolean initialize() {
+        if (botToken == null || botToken.isBlank()) {
+            plugin.getLogger().warning("Kein Discord-Bot-Token gesetzt. Discord-Funktion deaktiviert.");
+            return false;
+        }
+
         try {
             jda = JDABuilder.createDefault(botToken).build();
             jda.awaitReady(); // Warten, bis der Bot vollständig gestartet ist
+            return true;
         } catch (Exception e) {
-            e.printStackTrace();
+            plugin.getLogger().warning("Discord-Bot konnte nicht gestartet werden: " + e.getMessage());
+            return false;
         }
     }
 
@@ -38,13 +50,15 @@ public class DiscordNotifier {
     }
 
     private void sendMessage(String channelId, String message) {
-        if (jda != null) {
-            TextChannel channel = jda.getTextChannelById(channelId);
-            if (channel != null) {
-                channel.sendMessage(message).queue();
-            } else {
-                System.err.println("Textkanal nicht gefunden.");
-            }
+        if (jda == null || channelId == null || channelId.isBlank()) {
+            return;
+        }
+
+        TextChannel channel = jda.getTextChannelById(channelId);
+        if (channel != null) {
+            channel.sendMessage(message).queue();
+        } else {
+            plugin.getLogger().warning("Textkanal nicht gefunden.");
         }
     }
 


### PR DESCRIPTION
## Summary
- skip Discord setup if bot token is missing or invalid
- disable plugin when DB config is incomplete or connection fails

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68497dcad99883258c7704a836f994d3