### PR TITLE
Fix Discord shutdown race condition

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
@@ -65,6 +65,11 @@ public class DiscordNotifier {
     public void shutdown() {
         if (jda != null) {
             jda.shutdown();
+            try {
+                jda.awaitShutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure JDA client has finished shutting down before plugin unload

## Testing
- `mvn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684987b041fc8325a3ec70f24fb7cd45