### PR TITLE
Fix Discord shutdown message

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -89,8 +89,13 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
             getLogger().severe("Fehler beim Schließen der Datenbankverbindung: " + e.getMessage());
         }
 
-        // Discord Shutdown
+        // Discord-Benachrichtigung senden und Bot herunterfahren
         if (discordNotifier != null) {
+            String name = serverName != null
+                    ? serverName
+                    : getConfig().getString("default-server-name", "Unbekannt");
+            discordNotifier.sendServerNotification(
+                    "Plugin wurde auf Server " + name + " heruntergefahren");
             discordNotifier.shutdown();
         }
 

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
@@ -65,6 +65,11 @@ public class DiscordNotifier {
     public void shutdown() {
         if (jda != null) {
             jda.shutdown();
+            try {
+                jda.awaitShutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- send shutdown notification to Discord channel
- await JDA shutdown completion

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684987b041fc8325a3ec70f24fb7cd45