### PR TITLE
Fix Discord shutdown message

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -89,8 +89,13 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
             getLogger().severe("Fehler beim Schließen der Datenbankverbindung: " + e.getMessage());
         }
 
-        // Discord Shutdown
+        // Discord-Benachrichtigung senden und Bot herunterfahren
         if (discordNotifier != null) {
+            String name = serverName != null
+                    ? serverName
+                    : getConfig().getString("default-server-name", "Unbekannt");
+            discordNotifier.sendServerNotification(
+                    "Plugin wurde auf Server " + name + " heruntergefahren");
             discordNotifier.shutdown();
         }
 
@@ -134,6 +139,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         getCommand("report").setExecutor(new ReportCommand(this, discordNotifier));
         getCommand("report").setTabCompleter(new ReportTabCompleter());
         getCommand("viewreports").setExecutor(new ViewReportsCommand(this));
+        getCommand("viewreportsgui").setExecutor(new ViewReportsGuiCommand(this));
         getCommand("deletereport").setExecutor(new DeleteReportCommand(this, reportRepository));
         getCommand("deletereport").setTabCompleter(new DeleteReportTabCompleter(reportRepository));
     }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsCommand.java
@@ -31,8 +31,13 @@ public class ViewReportsCommand implements CommandExecutor {
         // Zugriff auf das ReportRepository
         ReportRepository reportRepository = plugin.getReportRepository();
 
-        // Alle offenen Reports abrufen
+        // Alle Reports abrufen und nur offene oder in Bearbeitung befindliche anzeigen
         List<Report> reports = reportRepository.getAllReports();
+        reports.removeIf(r -> {
+            String status = r.getStatus();
+            return status != null && !(status.equalsIgnoreCase("offen") || status.equalsIgnoreCase("in Bearbeitung"));
+        });
+        reports.sort((a, b) -> Integer.compare(getStatusOrder(a.getStatus()), getStatusOrder(b.getStatus())));
         if (reports.isEmpty()) {
             sender.sendMessage(ChatColor.YELLOW + "Keine Reports vorhanden.");
             return true;
@@ -66,5 +71,17 @@ public class ViewReportsCommand implements CommandExecutor {
     private String getPlayerNameFromUUID(String uuid) {
         OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(uuid));
         return player.getName() != null ? player.getName() : "Unbekannt";
+    }
+
+    private int getStatusOrder(String status) {
+        if (status == null) return 2;
+        switch (status.toLowerCase()) {
+            case "offen":
+                return 0;
+            case "in bearbeitung":
+                return 1;
+            default:
+                return 2;
+        }
     }
 }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
@@ -1,0 +1,131 @@
+package ch.ksrminecraft.akzuwoextension.commands;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.akzuwoextension.utils.Report;
+import ch.ksrminecraft.akzuwoextension.utils.ReportRepository;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.*;
+
+public class ViewReportsGuiCommand implements CommandExecutor, Listener {
+
+    private final AkzuwoExtension plugin;
+    private final ReportRepository reportRepository;
+    private final Map<UUID, Inventory> openInventories = new HashMap<>();
+    private final NamespacedKey idKey;
+
+    public ViewReportsGuiCommand(AkzuwoExtension plugin) {
+        this.plugin = plugin;
+        this.reportRepository = plugin.getReportRepository();
+        this.idKey = new NamespacedKey(plugin, "report_id");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Nur Spieler können dieses Kommando nutzen.");
+            return true;
+        }
+        if (!player.hasPermission("akzuwoextension.staff")) {
+            player.sendMessage(ChatColor.RED + "Keine Berechtigung.");
+            return true;
+        }
+
+        List<Report> reports = reportRepository.getAllReports();
+        reports.sort(Comparator.comparingInt(r -> getStatusOrder(r.getStatus())));
+
+        int size = Math.min(((reports.size() + 8) / 9) * 9, 54);
+        Inventory inv = Bukkit.createInventory(player, Math.max(size, 9), "Reports");
+
+        for (int i = 0; i < reports.size() && i < size; i++) {
+            Report report = reports.get(i);
+            ItemStack item = new ItemStack(Material.PAPER);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(ChatColor.YELLOW + "Report #" + report.getId());
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Melder: " + report.getReporterName());
+            lore.add(ChatColor.GRAY + "Gemeldeter: " + report.getPlayerName());
+            lore.add(ChatColor.GRAY + "Grund: " + report.getReason());
+            lore.add(ChatColor.GRAY + "Status: " + report.getStatus());
+            meta.setLore(lore);
+            meta.getPersistentDataContainer().set(idKey, PersistentDataType.INTEGER, report.getId());
+            item.setItemMeta(meta);
+            inv.addItem(item);
+        }
+
+        openInventories.put(player.getUniqueId(), inv);
+        player.openInventory(inv);
+        return true;
+    }
+
+    private int getStatusOrder(String status) {
+        if (status == null) return 3;
+        return switch (status.toLowerCase(Locale.ROOT)) {
+            case "offen" -> 0;
+            case "in bearbeitung" -> 1;
+            case "geschlossen" -> 2;
+            default -> 3;
+        };
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        Inventory inv = openInventories.get(player.getUniqueId());
+        if (inv == null || !event.getInventory().equals(inv)) return;
+
+        event.setCancelled(true);
+
+        ItemStack item = event.getCurrentItem();
+        if (item == null || item.getType() != Material.PAPER || !event.isRightClick()) {
+            return;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        Integer id = meta.getPersistentDataContainer().get(idKey, PersistentDataType.INTEGER);
+        if (id == null) return;
+
+        Report report = reportRepository.getReportById(id);
+        if (report == null) return;
+
+        String newStatus = null;
+        String status = report.getStatus();
+        if ("offen".equalsIgnoreCase(status)) {
+            newStatus = "in Bearbeitung";
+        } else if ("in Bearbeitung".equalsIgnoreCase(status)) {
+            newStatus = "geschlossen";
+        }
+
+        if (newStatus != null) {
+            reportRepository.updateReportStatus(id, newStatus);
+            List<String> lore = meta.getLore();
+            if (lore != null && lore.size() >= 4) {
+                lore.set(3, ChatColor.GRAY + "Status: " + newStatus);
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+                player.sendMessage(ChatColor.GREEN + "Report #" + id + " ist nun '" + newStatus + "'.");
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        openInventories.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
@@ -65,6 +65,11 @@ public class DiscordNotifier {
     public void shutdown() {
         if (jda != null) {
             jda.shutdown();
+            try {
+                jda.awaitShutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/ReportRepository.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/ReportRepository.java
@@ -159,4 +159,25 @@ public class ReportRepository  {
 
         return 0; // Rückgabe 0 bei Fehler
     }
+
+    /**
+     * Aktualisiert den Status eines Reports.
+     *
+     * @param reportId  Die ID des Reports
+     * @param newStatus Neuer Status
+     */
+    public void updateReportStatus(int reportId, String newStatus) {
+        String sql = "UPDATE reports SET status = ? WHERE id = ?";
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, newStatus);
+            statement.setInt(2, reportId);
+            statement.executeUpdate();
+
+        } catch (SQLException e) {
+            logger.severe("Fehler beim Aktualisieren des Report-Status: " + e.getMessage());
+        }
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,6 +9,9 @@ commands:
   viewreports:
     description: View all reports.
     usage: /viewreports
+  viewreportsgui:
+    description: View all reports in a GUI.
+    usage: /viewreportsgui
   deletereport:
     description: Delete a report by ID.
     usage: /deletereport <id>


### PR DESCRIPTION
## Summary
- send shutdown notification to Discord channel
- await JDA shutdown completion
- add `/viewreportsgui` with click actions for status updates
- filter `/viewreports` to only show open or in-progress reports

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684987b041fc8325a3ec70f24fb7cd45