### PR TITLE
Add GUI report management

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -75,6 +75,9 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
 
         // Commands und TabCompleter registrieren
         registerCommands();
+
+        // Listener registrieren
+        getServer().getPluginManager().registerEvents(new ViewReportsGuiListener(this), this);
     }
 
     @Override
@@ -139,6 +142,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         getCommand("report").setExecutor(new ReportCommand(this, discordNotifier));
         getCommand("report").setTabCompleter(new ReportTabCompleter());
         getCommand("viewreports").setExecutor(new ViewReportsCommand(this));
+        getCommand("viewreportsgui").setExecutor(new ViewReportsGuiCommand(this));
         getCommand("deletereport").setExecutor(new DeleteReportCommand(this, reportRepository));
         getCommand("deletereport").setTabCompleter(new DeleteReportTabCompleter(reportRepository));
     }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsCommand.java
@@ -31,8 +31,12 @@ public class ViewReportsCommand implements CommandExecutor {
         // Zugriff auf das ReportRepository
         ReportRepository reportRepository = plugin.getReportRepository();
 
-        // Alle offenen Reports abrufen
+        // Alle Reports abrufen
         List<Report> reports = reportRepository.getAllReports();
+        // Nur offene oder in Bearbeitung befindliche Reports anzeigen
+        reports.removeIf(r ->
+                !("offen".equalsIgnoreCase(r.getStatus()) ||
+                  "in Bearbeitung".equalsIgnoreCase(r.getStatus())));
         if (reports.isEmpty()) {
             sender.sendMessage(ChatColor.YELLOW + "Keine Reports vorhanden.");
             return true;

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
@@ -1,0 +1,99 @@
+package ch.ksrminecraft.akzuwoextension.commands;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.akzuwoextension.utils.Report;
+import ch.ksrminecraft.akzuwoextension.utils.ReportRepository;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+public class ViewReportsGuiCommand implements CommandExecutor {
+
+    private final AkzuwoExtension plugin;
+
+    public ViewReportsGuiCommand(AkzuwoExtension plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Nur Spieler können dieses Kommando verwenden.");
+            return true;
+        }
+        if (!sender.hasPermission("akzuwoextension.staff")) {
+            sender.sendMessage(ChatColor.RED + "Keine Berechtigung.");
+            return true;
+        }
+
+        ReportRepository repo = plugin.getReportRepository();
+        List<Report> reports = repo.getAllReports();
+        if (reports.isEmpty()) {
+            sender.sendMessage(ChatColor.YELLOW + "Keine Reports vorhanden.");
+            return true;
+        }
+
+        reports.sort(Comparator.comparingInt(r -> getStatusOrder(r.getStatus())));
+        int size = ((reports.size() - 1) / 9 + 1) * 9;
+        size = Math.min(size, 54);
+
+        Inventory inventory = Bukkit.createInventory(new ReportsHolder(), size, ChatColor.DARK_RED + "Reports");
+        NamespacedKey key = new NamespacedKey(plugin, "reportId");
+
+        for (int i = 0; i < Math.min(reports.size(), size); i++) {
+            Report report = reports.get(i);
+            ItemStack item = new ItemStack(Material.PAPER);
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.YELLOW + "ID " + report.getId() + " [" + report.getStatus() + "]");
+                List<String> lore = new ArrayList<>();
+                lore.add(ChatColor.GRAY + "Melder: " + report.getReporterName());
+                lore.add(ChatColor.GRAY + "Gemeldete: " + getPlayerNameFromUUID(report.getPlayerUUID()));
+                lore.add(ChatColor.GRAY + "Grund: " + report.getReason());
+                meta.setLore(lore);
+                meta.getPersistentDataContainer().set(key, PersistentDataType.INTEGER, report.getId());
+                item.setItemMeta(meta);
+            }
+            inventory.setItem(i, item);
+        }
+
+        ((Player) sender).openInventory(inventory);
+        return true;
+    }
+
+    private int getStatusOrder(String status) {
+        if (status == null) return 3;
+        if (status.equalsIgnoreCase("offen")) return 0;
+        if (status.equalsIgnoreCase("in Bearbeitung")) return 1;
+        if (status.equalsIgnoreCase("geschlossen")) return 2;
+        return 3;
+    }
+
+    private String getPlayerNameFromUUID(String uuid) {
+        OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(uuid));
+        return player.getName() != null ? player.getName() : "Unbekannt";
+    }
+
+    public static class ReportsHolder implements InventoryHolder {
+        @Override
+        public Inventory getInventory() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
@@ -1,0 +1,67 @@
+package ch.ksrminecraft.akzuwoextension.commands;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.akzuwoextension.utils.Report;
+import ch.ksrminecraft.akzuwoextension.utils.ReportRepository;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+public class ViewReportsGuiListener implements Listener {
+
+    private final AkzuwoExtension plugin;
+
+    public ViewReportsGuiListener(AkzuwoExtension plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        if (!(event.getInventory().getHolder() instanceof ViewReportsGuiCommand.ReportsHolder)) {
+            return;
+        }
+        event.setCancelled(true);
+
+        if (event.getCurrentItem() == null || event.getCurrentItem().getType() != Material.PAPER) {
+            return;
+        }
+        if (!event.getClick().isRightClick()) {
+            return;
+        }
+
+        ItemMeta meta = event.getCurrentItem().getItemMeta();
+        if (meta == null) return;
+        NamespacedKey key = new NamespacedKey(plugin, "reportId");
+        Integer id = meta.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);
+        if (id == null) return;
+
+        ReportRepository repo = plugin.getReportRepository();
+        Report report = repo.getReportById(id);
+        if (report == null) return;
+
+        String status = report.getStatus();
+        String newStatus = null;
+        if ("offen".equalsIgnoreCase(status)) {
+            newStatus = "in Bearbeitung";
+        } else if ("in Bearbeitung".equalsIgnoreCase(status)) {
+            newStatus = "geschlossen";
+        }
+
+        if (newStatus != null) {
+            repo.updateReportStatus(id, newStatus);
+            meta.setDisplayName(ChatColor.YELLOW + "ID " + id + " [" + newStatus + "]");
+            event.getCurrentItem().setItemMeta(meta);
+            ((Player) event.getWhoClicked()).sendMessage(ChatColor.GREEN + "Report " + id + " ist nun " + newStatus + ".");
+        }
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/ReportRepository.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/ReportRepository.java
@@ -138,6 +138,27 @@ public class ReportRepository  {
     }
 
     /**
+     * Aktualisiert den Status eines Reports.
+     *
+     * @param reportId Die ID des Reports
+     * @param status   Neuer Status
+     */
+    public void updateReportStatus(int reportId, String status) {
+        String sql = "UPDATE reports SET status = ? WHERE id = ?";
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, status);
+            statement.setInt(2, reportId);
+            statement.executeUpdate();
+
+        } catch (SQLException e) {
+            logger.severe("Fehler beim Aktualisieren des Report-Status: " + e.getMessage());
+        }
+    }
+
+    /**
      * Gibt die Anzahl aller gespeicherten Reports zurück.
      *
      * @return Anzahl der Reports

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,6 +9,9 @@ commands:
   viewreports:
     description: View all reports.
     usage: /viewreports
+  viewreportsgui:
+    description: View all reports in a GUI.
+    usage: /viewreportsgui
   deletereport:
     description: Delete a report by ID.
     usage: /deletereport <id>


### PR DESCRIPTION
## Summary
- add `/viewreportsgui` command and listener
- store report id in item meta and change status with right click
- filter `/viewreports` output to open and in-progress items
- support status updates in `ReportRepository`
- register new command and listener
- document new command in `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684abd8036e48325b80d8ed6d509cb56