### PR TITLE
Implement confirmation step and GUI status toggles

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -17,6 +17,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
     private ReportRepository reportRepository;
     private DiscordNotifier discordNotifier;
     private String serverName;
+    private final java.util.Map<String, Integer> pendingDeleteReports = new java.util.HashMap<>();
 
     @Override
     public void onEnable() {
@@ -117,7 +118,8 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
 
         // Discord-Benachrichtigung senden
         if (discordNotifier != null) {
-            discordNotifier.sendServerNotification("Plugin erfolgreich gestartet auf Server: " + serverName);
+            String version = getDescription().getVersion();
+            discordNotifier.sendServerNotification("Plugin Version " + version + " erfolgreich gestartet auf Server: " + serverName);
         } else {
             getLogger().warning("DiscordNotifier ist nicht initialisiert.");
         }
@@ -145,6 +147,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         getCommand("viewreportsgui").setExecutor(new ViewReportsGuiCommand(this));
         getCommand("deletereport").setExecutor(new DeleteReportCommand(this, reportRepository));
         getCommand("deletereport").setTabCompleter(new DeleteReportTabCompleter(reportRepository));
+        getCommand("akzuwoextension").setExecutor(new AkzuwoExtensionCommand(this));
     }
 
     public ReportRepository getReportRepository() {
@@ -153,6 +156,14 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
 
     public String getServerName() {
         return serverName;
+    }
+
+    public void setPendingDelete(String sender, int id) {
+        pendingDeleteReports.put(sender, id);
+    }
+
+    public Integer pollPendingDelete(String sender) {
+        return pendingDeleteReports.remove(sender);
     }
 }
 

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/AkzuwoExtensionCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/AkzuwoExtensionCommand.java
@@ -1,0 +1,41 @@
+package ch.ksrminecraft.akzuwoextension.commands;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.akzuwoextension.utils.Report;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class AkzuwoExtensionCommand implements CommandExecutor {
+
+    private final AkzuwoExtension plugin;
+
+    public AkzuwoExtensionCommand(AkzuwoExtension plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 1 && args[0].equalsIgnoreCase("confirm")) {
+            Integer reportId = plugin.pollPendingDelete(sender.getName());
+            if (reportId == null) {
+                sender.sendMessage(ChatColor.RED + "Es gibt keinen Löschvorgang zu bestätigen.");
+                return true;
+            }
+
+            Report report = plugin.getReportRepository().getReportById(reportId);
+            if (report == null) {
+                sender.sendMessage(ChatColor.RED + "Report mit der ID " + reportId + " wurde nicht gefunden.");
+                return true;
+            }
+
+            plugin.getReportRepository().deleteReportById(reportId);
+            sender.sendMessage(ChatColor.GREEN + "Report mit der ID " + reportId + " wurde erfolgreich gelöscht.");
+            return true;
+        }
+
+        sender.sendMessage(ChatColor.RED + "Verwendung: /akzuwoextension confirm");
+        return true;
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/DeleteReportCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/DeleteReportCommand.java
@@ -42,9 +42,9 @@ public class DeleteReportCommand implements CommandExecutor {
                 return true;
             }
 
-            // Löschen des Reports aus der Datenbank
-            reportRepository.deleteReportById(reportId);
-            sender.sendMessage(ChatColor.GREEN + "Report mit der ID " + reportId + " wurde erfolgreich gelöscht.");
+            // Löschvorgang vormerken
+            plugin.setPendingDelete(sender.getName(), reportId);
+            sender.sendMessage(ChatColor.YELLOW + "Bestätige das Löschen mit /akzuwoextension confirm.");
         } catch (NumberFormatException e) {
             sender.sendMessage(ChatColor.RED + "Die angegebene Report-ID ist ungültig.");
         }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
@@ -28,7 +28,8 @@ public class ReportCommand implements CommandExecutor {
 
         @Nullable String serverName = plugin.getConfig().getString("default-server-name");
         if (discordNotifier != null) {
-            discordNotifier.sendServerNotification("Plugin erfolgreich gestartet auf Server: " + serverName);
+            String version = plugin.getDescription().getVersion();
+            discordNotifier.sendServerNotification("Plugin Version " + version + " erfolgreich gestartet auf Server: " + serverName);
         } else {
             plugin.getLogger().warning("DiscordNotifier ist nicht initialisiert.");
         }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
@@ -35,7 +35,9 @@ public class ViewReportsGuiListener implements Listener {
         if (event.getCurrentItem() == null || event.getCurrentItem().getType() != Material.PAPER) {
             return;
         }
-        if (!event.getClick().isRightClick()) {
+        boolean rightClick = event.getClick().isRightClick();
+        boolean leftClick = event.getClick().isLeftClick();
+        if (!rightClick && !leftClick) {
             return;
         }
 
@@ -51,10 +53,18 @@ public class ViewReportsGuiListener implements Listener {
 
         String status = report.getStatus();
         String newStatus = null;
-        if ("offen".equalsIgnoreCase(status)) {
-            newStatus = "in Bearbeitung";
-        } else if ("in Bearbeitung".equalsIgnoreCase(status)) {
-            newStatus = "geschlossen";
+        if (rightClick) {
+            if ("offen".equalsIgnoreCase(status)) {
+                newStatus = "in Bearbeitung";
+            } else if ("in Bearbeitung".equalsIgnoreCase(status)) {
+                newStatus = "geschlossen";
+            }
+        } else if (leftClick) {
+            if ("geschlossen".equalsIgnoreCase(status)) {
+                newStatus = "in Bearbeitung";
+            } else if ("in Bearbeitung".equalsIgnoreCase(status)) {
+                newStatus = "offen";
+            }
         }
 
         if (newStatus != null) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,9 @@ commands:
   deletereport:
     description: Delete a report by ID.
     usage: /deletereport <id>
+  akzuwoextension:
+    description: Base command for confirmations.
+    usage: /akzuwoextension confirm
 
 tutorialcommand: true
 


### PR DESCRIPTION
## Summary
- add new `/akzuwoextension confirm` command for report deletions
- make `/deletereport` require confirmation
- toggle report status backwards on left click in GUI
- send plugin version in Discord start message

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ad21f19748325a3ace584d6cef085