### PR TITLE
Add RankPoints placeholder with configurable API integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,5 +98,10 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.27</version> <!-- Aktuelle Version prüfen -->
         </dependency>
+        <dependency>
+            <groupId>com.github.Samhuwsluz</groupId>
+            <artifactId>RankPointsAPI</artifactId>
+            <version>v0.1.5</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
@@ -1,0 +1,61 @@
+package ch.ksrminecraft.akzuwoextension.utils;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.RankPointsAPI.PointsAPI;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+
+/**
+ * Placeholder für die RankPointsAPI.
+ */
+public class RankPointsPlaceholder extends PlaceholderExpansion {
+
+    private final AkzuwoExtension plugin;
+
+    public RankPointsPlaceholder(AkzuwoExtension plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "akzuwo";
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Akzuwo";
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier) {
+        if (player == null) {
+            return "";
+        }
+
+        if (identifier.equalsIgnoreCase("rankpoints")) {
+            PointsAPI api = plugin.getPointsAPI();
+            if (api != null) {
+                return String.valueOf(api.getPoints(player.getUniqueId()));
+            }
+            return "0";
+        }
+
+        return null;
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,10 +1,20 @@
-# Datenbankkonfiguration für das Plugin
+# Datenbankkonfiguration für das Report-System
 database:
   host: ""
   port: 3306
   name: ""
   username: ""
   password: ""
+
+# RankPointsAPI Konfiguration
+rankpointsapi:
+  integration: true
+  host: ""
+  port: 3306
+  name: ""
+  username: ""
+  password: ""
+
 discord-bot-token: ""
 discord-channel-id-reports: ""
 discord-channel-id-notifications: ""


### PR DESCRIPTION
## Summary
- expose `%akzuwo_rankpoints%` placeholder via new `RankPointsPlaceholder`
- initialize `RankPointsAPI` to fetch player points and register placeholder
- add RankPointsAPI dependency
- allow separate database credentials and optional disabling of RankPointsAPI integration

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac625c78ac8325a14b5953c274ce98