### PR TITLE
Add prefixed logger with yellow warning messages

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
@@ -31,7 +31,7 @@ public class ReportCommand implements CommandExecutor {
             String version = plugin.getDescription().getVersion();
             discordNotifier.sendServerNotification("Plugin Version " + version + " erfolgreich gestartet auf Server: " + serverName);
         } else {
-            plugin.getLogger().warning("DiscordNotifier ist nicht initialisiert.");
+            plugin.getPrefixedLogger().warning("DiscordNotifier ist nicht initialisiert.");
         }
     }
 
@@ -114,7 +114,7 @@ public class ReportCommand implements CommandExecutor {
         ReportRepository reportRepository = plugin.getReportRepository();
         if (reportRepository == null) {
             sender.sendMessage(ChatColor.RED + "Es gab ein Problem mit der Report-Datenbank. Bitte versuche es später erneut.");
-            plugin.getLogger().severe("ReportRepository ist null. Report konnte nicht gespeichert werden.");
+            plugin.getPrefixedLogger().severe("ReportRepository ist null. Report konnte nicht gespeichert werden.");
             return true;
         }
 
@@ -124,7 +124,7 @@ public class ReportCommand implements CommandExecutor {
             sender.sendMessage(ChatColor.GREEN + "Report gegen " + ChatColor.YELLOW + reportedPlayer.getName() + ChatColor.GREEN + " wurde erfolgreich eingereicht.");
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "Fehler beim Speichern des Reports. Bitte versuche es später erneut.");
-            plugin.getLogger().severe("Fehler beim Speichern des Reports: " + e.getMessage());
+            plugin.getPrefixedLogger().severe("Fehler beim Speichern des Reports: " + e.getMessage());
             return true;
         }
 

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/DiscordNotifier.java
@@ -27,7 +27,7 @@ public class DiscordNotifier {
      */
     public boolean initialize() {
         if (botToken == null || botToken.isBlank()) {
-            plugin.getLogger().warning("Kein Discord-Bot-Token gesetzt. Discord-Funktion deaktiviert.");
+            plugin.getPrefixedLogger().warning("Kein Discord-Bot-Token gesetzt. Discord-Funktion deaktiviert.");
             return false;
         }
 
@@ -36,7 +36,7 @@ public class DiscordNotifier {
             jda.awaitReady(); // Warten, bis der Bot vollständig gestartet ist
             return true;
         } catch (Exception e) {
-            plugin.getLogger().warning("Discord-Bot konnte nicht gestartet werden: " + e.getMessage());
+            plugin.getPrefixedLogger().warning("Discord-Bot konnte nicht gestartet werden: " + e.getMessage());
             return false;
         }
     }
@@ -58,7 +58,7 @@ public class DiscordNotifier {
         if (channel != null) {
             channel.sendMessage(message).queue();
         } else {
-            plugin.getLogger().warning("Textkanal nicht gefunden.");
+            plugin.getPrefixedLogger().warning("Textkanal nicht gefunden.");
         }
     }
 

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/PrefixedLogger.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/PrefixedLogger.java
@@ -1,0 +1,49 @@
+package ch.ksrminecraft.akzuwoextension.utils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.bukkit.ChatColor;
+
+/**
+ * Logger that prefixes all messages with the plugin name and colors warnings yellow.
+ */
+public class PrefixedLogger extends Logger {
+    private static final String PREFIX = "[AkzuwoExtension] ";
+    private final Logger base;
+
+    public PrefixedLogger(Logger base) {
+        super(base.getName(), null);
+        this.base = base;
+        setParent(base.getParent());
+        setLevel(base.getLevel());
+    }
+
+    @Override
+    public void info(String msg) {
+        base.info(PREFIX + msg);
+    }
+
+    @Override
+    public void warning(String msg) {
+        base.warning(ChatColor.YELLOW + PREFIX + msg + ChatColor.RESET);
+    }
+
+    @Override
+    public void severe(String msg) {
+        base.severe(PREFIX + msg);
+    }
+
+    @Override
+    public void log(Level level, String msg) {
+        if (level == Level.WARNING) {
+            warning(msg);
+        } else if (level == Level.INFO) {
+            info(msg);
+        } else if (level == Level.SEVERE) {
+            severe(msg);
+        } else {
+            base.log(level, PREFIX + msg);
+        }
+    }
+}
+

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/UpdateChecker.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/UpdateChecker.java
@@ -25,26 +25,26 @@ public class UpdateChecker {
                 connection.setReadTimeout(5000);
 
                 if (connection.getResponseCode() != 200) {
-                    plugin.getLogger().warning("Konnte nicht auf Update-Server zugreifen.");
+                    plugin.getPrefixedLogger().warning("Konnte nicht auf Update-Server zugreifen.");
                     return;
                 }
 
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
                     String latest = reader.readLine();
                     if (latest == null) {
-                        plugin.getLogger().warning("Ungültige Antwort vom Update-Server.");
+                        plugin.getPrefixedLogger().warning("Ungültige Antwort vom Update-Server.");
                         return;
                     }
 
                     String current = plugin.getDescription().getVersion();
                     if (!current.equalsIgnoreCase(latest.trim())) {
-                        plugin.getLogger().info("Eine neue Version (" + latest + ") ist verfügbar!");
+                        plugin.getPrefixedLogger().info("Eine neue Version (" + latest + ") ist verfügbar!");
                     } else {
-                        plugin.getLogger().info("Plugin ist auf dem neuesten Stand.");
+                        plugin.getPrefixedLogger().info("Plugin ist auf dem neuesten Stand.");
                     }
                 }
             } catch (Exception e) {
-                plugin.getLogger().warning("Fehler beim Prüfen auf Updates: " + e.getMessage());
+                plugin.getPrefixedLogger().warning("Fehler beim Prüfen auf Updates: " + e.getMessage());
             }
         });
     }


### PR DESCRIPTION
## Summary
- Introduce `PrefixedLogger` to prepend `[AkzuwoExtension]` to all console messages and color warnings yellow
- Use the new logger across the plugin for database, Discord, and update messages

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b03cd5653883259541981dad2838f4