### PR TITLE
feat: add database mode toggle

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -40,30 +40,37 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         }
 
         // Datenbankkonfiguration aus config.yml laden
-        String host = getConfig().getString("database.host");
-        int port = getConfig().getInt("database.port");
-        String database = getConfig().getString("database.name");
-        String username = getConfig().getString("database.username");
-        String password = getConfig().getString("database.password");
-
-        // Datenbankverbindung und Repository initialisieren
-        if (host == null || host.isBlank() || database == null || database.isBlank()
-                || username == null || username.isBlank() || password == null || password.isBlank()) {
-            logger.warning("Ungültige Datenbankkonfiguration, Offline-Modus wird verwendet.");
+        boolean databaseEnabled = getConfig().getBoolean("database.enabled", false);
+        if (!databaseEnabled) {
+            logger.info("Datenbank in config.yml deaktiviert, Offline-Modus wird verwendet.");
             databaseManager = null;
             reportRepository = new ReportRepository(null, logger, getDataFolder());
         } else {
-            databaseManager = new DatabaseManager(host, port, database, username, password);
-            try {
-                databaseManager.connect();
-                reportRepository = new ReportRepository(databaseManager, logger, getDataFolder());
-                reportRepository.migrateOfflineReports();
-                logger.info("Datenbank erfolgreich verbunden.");
-            } catch (SQLException e) {
-                logger.warning("Datenbankverbindung konnte nicht hergestellt werden, Offline-Modus wird verwendet.");
-                e.printStackTrace();
+            String host = getConfig().getString("database.host");
+            int port = getConfig().getInt("database.port");
+            String database = getConfig().getString("database.name");
+            String username = getConfig().getString("database.username");
+            String password = getConfig().getString("database.password");
+
+            // Datenbankverbindung und Repository initialisieren
+            if (host == null || host.isBlank() || database == null || database.isBlank()
+                    || username == null || username.isBlank() || password == null || password.isBlank()) {
+                logger.warning("Ungültige Datenbankkonfiguration, Offline-Modus wird verwendet.");
                 databaseManager = null;
                 reportRepository = new ReportRepository(null, logger, getDataFolder());
+            } else {
+                databaseManager = new DatabaseManager(host, port, database, username, password);
+                try {
+                    databaseManager.connect();
+                    reportRepository = new ReportRepository(databaseManager, logger, getDataFolder());
+                    reportRepository.migrateOfflineReports();
+                    logger.info("Datenbank erfolgreich verbunden.");
+                } catch (SQLException e) {
+                    logger.warning("Datenbankverbindung konnte nicht hergestellt werden, Offline-Modus wird verwendet.");
+                    e.printStackTrace();
+                    databaseManager = null;
+                    reportRepository = new ReportRepository(null, logger, getDataFolder());
+                }
             }
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 # Datenbankkonfiguration für das Report-System
 database:
+  enabled: false
   host: ""
   port: 3306
   name: ""


### PR DESCRIPTION
## Summary
- add `database.enabled` flag to config
- respect new flag to switch between SQL and JSON storage

## Testing
- `mvn -q -e package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bae2e3b7a08325a85c84e1f4a260ed