### PR TITLE
Add connection pooling for RankPoints and configurable check interval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
             <version>8.0.27</version> <!-- Aktuelle Version prüfen -->
         </dependency>
         <dependency>
-            <groupId>com.github.timylinigersluz</groupId>
-            <artifactId>RankPointsAPI</artifactId>
-            <version>v0.0.1</version>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ch/ksrminecraft/RankPointsAPI/PointsAPI.java
+++ b/src/main/java/ch/ksrminecraft/RankPointsAPI/PointsAPI.java
@@ -1,0 +1,135 @@
+package ch.ksrminecraft.RankPointsAPI;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.*;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Simplified RankPoints API implementation using a connection pool.
+ */
+public class PointsAPI {
+
+    private final Logger logger;
+    private final boolean debug;
+    private final HikariDataSource dataSource;
+
+    public PointsAPI(String url, String user, String password, Logger logger, boolean debug) {
+        this.logger = logger;
+        this.debug = debug;
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(url);
+        config.setUsername(user);
+        config.setPassword(password);
+        config.setMaximumPoolSize(10);
+        this.dataSource = new HikariDataSource(config);
+        ensureTables();
+    }
+
+    private Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    private void ensureTables() {
+        try (Connection con = getConnection();
+             Statement st = con.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS points (UUID VARCHAR(36) PRIMARY KEY,points INT NOT NULL DEFAULT 0)");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS stafflist (UUID VARCHAR(36) PRIMARY KEY,name VARCHAR(50) NOT NULL)");
+            if (debug) {
+                logger.info("[RankPointsAPI] Table 'points' checked/created.");
+                logger.info("[RankPointsAPI] Table 'stafflist' checked/created.");
+            }
+        } catch (SQLException e) {
+            logger.severe("[RankPointsAPI] Could not ensure tables: " + e.getMessage());
+        }
+    }
+
+    private boolean isStaff(UUID uuid) {
+        String sql = "SELECT UUID FROM stafflist WHERE UUID = ?";
+        try (Connection con = getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            logger.warning("[RankPointsAPI] Failed to check staff status: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public void setPoints(UUID uuid, int points) {
+        if (isStaff(uuid)) {
+            if (debug) {
+                logger.info("[RankPointsAPI] Attempt to modify staff member " + uuid);
+            }
+            return;
+        }
+        String sql = "INSERT INTO points (UUID, points) VALUES (?, ?) ON DUPLICATE KEY UPDATE points=?";
+        try (Connection con = getConnection();
+             PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            ps.setInt(2, points);
+            ps.setInt(3, points);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            logger.warning("[RankPointsAPI] Failed to set points: " + e.getMessage());
+        }
+    }
+
+    public boolean addPoints(UUID uuid, int delta) {
+        if (isStaff(uuid)) {
+            if (debug) {
+                logger.info("[RankPointsAPI] Attempt to modify staff member " + uuid);
+            }
+            return false;
+        }
+        String ensureSql = "INSERT INTO points (UUID, points) VALUES (?, 0) ON DUPLICATE KEY UPDATE UUID=UUID";
+        String updateSql = "UPDATE points SET points = points + ? WHERE UUID=?";
+        try (Connection con = getConnection()) {
+            try (PreparedStatement ps = con.prepareStatement(ensureSql)) {
+                ps.setString(1, uuid.toString());
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = con.prepareStatement(updateSql)) {
+                ps.setInt(1, delta);
+                ps.setString(2, uuid.toString());
+                ps.executeUpdate();
+            }
+            return true;
+        } catch (SQLException e) {
+            logger.warning("[RankPointsAPI] Failed to add points: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public int getPoints(UUID uuid) {
+        String ensureSql = "INSERT INTO points (UUID, points) VALUES (?, 0) ON DUPLICATE KEY UPDATE UUID=UUID";
+        String selectSql = "SELECT points FROM points WHERE UUID=?";
+        try (Connection con = getConnection()) {
+            try (PreparedStatement ps = con.prepareStatement(ensureSql)) {
+                ps.setString(1, uuid.toString());
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = con.prepareStatement(selectSql)) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return rs.getInt("points");
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            logger.warning("[RankPointsAPI] Failed to get points: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    public void close() throws SQLException {
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -19,6 +19,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
     private ReportRepository reportRepository;
     private DiscordNotifier discordNotifier;
     private PointsAPI pointsAPI;
+    private long rankPointsCheckInterval;
     private String serverName;
     private final java.util.Map<String, Integer> pendingDeleteReports = new java.util.HashMap<>();
 
@@ -75,6 +76,7 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         }
 
         // RankPointsAPI initialisieren, falls in der Config aktiviert
+        rankPointsCheckInterval = getConfig().getLong("rankpointsapi.check-interval", 10) * 1000L;
         if (getConfig().getBoolean("rankpointsapi.integration", true)) {
             String rpHost = getConfig().getString("rankpointsapi.host");
             int rpPort = getConfig().getInt("rankpointsapi.port");
@@ -143,9 +145,9 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
         }
 
         // RankPointsAPI Verbindung schließen
-        if (pointsAPI != null && pointsAPI.getConnection() != null) {
+        if (pointsAPI != null) {
             try {
-                pointsAPI.getConnection().close();
+                pointsAPI.close();
             } catch (SQLException e) {
                 logger.severe("Fehler beim Schließen der RankPointsAPI-Verbindung: " + e.getMessage());
             }
@@ -220,5 +222,9 @@ public class AkzuwoExtension extends JavaPlugin implements PluginMessageListener
 
     public PointsAPI getPointsAPI() {
         return pointsAPI;
+    }
+
+    public long getRankPointsCheckInterval() {
+        return rankPointsCheckInterval;
     }
 }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
@@ -16,9 +16,11 @@ public class RankPointsPlaceholder extends PlaceholderExpansion {
 
     private final AkzuwoExtension plugin;
     private final Map<UUID, CacheEntry> cache = new HashMap<>();
+    private final long cacheDuration;
 
     public RankPointsPlaceholder(AkzuwoExtension plugin) {
         this.plugin = plugin;
+        this.cacheDuration = plugin.getRankPointsCheckInterval();
     }
 
     @Override
@@ -58,7 +60,7 @@ public class RankPointsPlaceholder extends PlaceholderExpansion {
                 UUID uuid = player.getUniqueId();
                 long now = System.currentTimeMillis();
                 CacheEntry entry = cache.get(uuid);
-                if (entry == null || now - entry.timestamp > 10_000) {
+                if (entry == null || now - entry.timestamp > cacheDuration) {
                     int points = api.getPoints(uuid);
                     entry = new CacheEntry(points, now);
                     cache.put(uuid, entry);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,7 @@ rankpointsapi:
   name: ""
   username: ""
   password: ""
+  check-interval: 10 # Seconds between RankPoints database queries
 
 discord-bot-token: ""
 discord-channel-id-reports: ""


### PR DESCRIPTION
## Summary
- Replace external RankPointsAPI with internal implementation using HikariCP connection pooling
- Allow RankPoints rank polling interval to be configured in `config.yml`
- Expose interval to placeholder caching and close pooled connections on shutdown

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cba3bf8c83258ae20995abfd0cc8