### PR TITLE
Move PointsAPI into utils package

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -2,7 +2,6 @@ package ch.ksrminecraft.akzuwoextension;
 
 import ch.ksrminecraft.akzuwoextension.commands.*;
 import ch.ksrminecraft.akzuwoextension.utils.*;
-import ch.ksrminecraft.RankPointsAPI.PointsAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/PointsAPI.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/PointsAPI.java
@@ -1,4 +1,4 @@
-package ch.ksrminecraft.RankPointsAPI;
+package ch.ksrminecraft.akzuwoextension.utils;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/utils/RankPointsPlaceholder.java
@@ -1,7 +1,6 @@
 package ch.ksrminecraft.akzuwoextension.utils;
 
 import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
-import ch.ksrminecraft.RankPointsAPI.PointsAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
 


### PR DESCRIPTION
## Summary
- relocate PointsAPI from RankPointsAPI to akzuwoextension.utils package
- update imports and references to new PointsAPI location

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable for plugin artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d5d4ffd88325810c91025a6ff1a4