### PR TITLE
Add permissions section to plugin descriptor

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,11 @@ softdepend: [PlaceholderAPI]
 
 
 
+permissions:
+  akzuwoextension.staff:
+    description: Allows staff members to manage and review player reports.
+    default: op
+  akzuwoextension.exempt:
+    description: Prevents a player from being reported by others.
+    default: false
+


### PR DESCRIPTION
## Summary
- document the plugin's staff and exempt permissions in `plugin.yml` with descriptions and sensible defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a2e14e248325b3fd1c4e6d48c3aa