### PR TITLE
Add permissions section to plugin descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ AkzuwoExtension ist ein Spigot-Plugin, das ein erweitertes Reportsystem mit Disc
 - `%akzuwoextension_cet_time%` – Aktuelle Uhrzeit in Mitteleuropa.
 - `%akzuwo_rankpoints%` – RankPoints des Spielers (nur wenn die RankPointsAPI konfiguriert ist).
 
+## Berechtigungen
+- `akzuwoextension.staff` – Ermöglicht Teammitgliedern, Reports zu verwalten und einzusehen.
+- `akzuwoextension.exempt` – Verhindert, dass ein Spieler über das Reportsystem gemeldet werden kann.
+
 ## Installation
 1. Platziere das Plugin in deinem `plugins`-Ordner.
 2. Starte den Server damit die config.yml generiert wird.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,11 @@ softdepend: [PlaceholderAPI]
 
 
 
+permissions:
+  akzuwoextension.staff:
+    description: Allows staff members to manage and review player reports.
+    default: op
+  akzuwoextension.exempt:
+    description: Prevents a player from being reported by others.
+    default: false
+


### PR DESCRIPTION
## Summary
- document the plugin's staff and exempt permissions in `plugin.yml` with descriptions and sensible defaults
- add a permissions overview to the README so administrators can see the available nodes at a glance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a2e14e248325b3fd1c4e6d48c3aa