### PR TITLE
Remove proxy server name retrieval

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
@@ -10,7 +10,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -26,7 +25,7 @@ public class ReportCommand implements CommandExecutor {
         this.plugin = plugin;
         this.discordNotifier = discordNotifier;
 
-        @Nullable String serverName = plugin.getConfig().getString("default-server-name");
+        String serverName = plugin.getServerName();
         if (discordNotifier != null) {
             String version = plugin.getDescription().getVersion();
             discordNotifier.sendServerNotification("Plugin Version " + version + " erfolgreich gestartet auf Server: " + serverName);


### PR DESCRIPTION
## Summary
- remove the plugin messaging channel that requested the server name from the proxy
- initialise the server name from the configuration and reuse it in the report command notification

## Testing
- mvn -q -DskipTests package *(fails: dependency download blocked by HTTP 403 from repo.papermc.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a772a0448325bba341d9295c7919