### PR TITLE
Add Discord notifications for report status updates

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -168,6 +168,10 @@ public class AkzuwoExtension extends JavaPlugin {
         return logger;
     }
 
+    public DiscordNotifier getDiscordNotifier() {
+        return discordNotifier;
+    }
+
     public String getServerName() {
         return serverName;
     }


### PR DESCRIPTION
## Summary
- expose the plugin's DiscordNotifier so listeners can access it
- notify Discord when report statuses change via the GUI and log missing notifier configuration

## Testing
- mvn -q -DskipTests compile *(fails: dependency repository returns 403 without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b091ea7083258b1525603663fc44