### PR TITLE
Add pagination and filtering to report GUI

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiCommand.java
@@ -5,6 +5,8 @@ import ch.ksrminecraft.akzuwoextension.utils.Report;
 import ch.ksrminecraft.akzuwoextension.utils.ReportRepository;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -14,21 +16,29 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
 public class ViewReportsGuiCommand implements CommandExecutor {
 
+    public static final String REPORT_ID_KEY = "reportId";
+    public static final String CONTROL_KEY = "reportsControl";
+    private static final int INVENTORY_SIZE = 54;
+    private static final int ITEMS_PER_PAGE = 45;
+
     private final AkzuwoExtension plugin;
+    private final NamespacedKey reportIdKey;
+    private final NamespacedKey controlKey;
 
     public ViewReportsGuiCommand(AkzuwoExtension plugin) {
         this.plugin = plugin;
+        this.reportIdKey = new NamespacedKey(plugin, REPORT_ID_KEY);
+        this.controlKey = new NamespacedKey(plugin, CONTROL_KEY);
     }
 
     @Override
@@ -42,21 +52,36 @@ public class ViewReportsGuiCommand implements CommandExecutor {
             return true;
         }
 
-        ReportRepository repo = plugin.getReportRepository();
-        List<Report> reports = repo.getAllReports();
-        if (reports.isEmpty()) {
-            sender.sendMessage(ChatColor.YELLOW + "Keine Reports vorhanden.");
-            return true;
+        Player player = (Player) sender;
+        ReportsHolder holder = new ReportsHolder(this);
+        Inventory inventory = Bukkit.createInventory(holder, INVENTORY_SIZE, ChatColor.DARK_RED + "Reports");
+        populateInventory(inventory, holder);
+        player.openInventory(inventory);
+        if (holder.getTotalReports() == 0) {
+            player.sendMessage(ChatColor.YELLOW + "Keine Reports vorhanden.");
+        }
+        sendStatusMessage(player, holder);
+        return true;
+    }
+
+    void populateInventory(Inventory inventory, ReportsHolder holder) {
+        inventory.clear();
+
+        List<Report> reports = getFilteredReports(holder.isOnlyOpen());
+        holder.setTotalReports(reports.size());
+
+        int totalPages = Math.max(1, (int) Math.ceil((double) reports.size() / ITEMS_PER_PAGE));
+        holder.setTotalPages(totalPages);
+
+        if (holder.getPage() >= totalPages) {
+            holder.setPage(totalPages - 1);
         }
 
-        reports.sort(Comparator.comparingInt(r -> getStatusOrder(r.getStatus())));
-        int size = ((reports.size() - 1) / 9 + 1) * 9;
-        size = Math.min(size, 54);
+        int startIndex = holder.getPage() * ITEMS_PER_PAGE;
+        int endIndex = Math.min(startIndex + ITEMS_PER_PAGE, reports.size());
 
-        Inventory inventory = Bukkit.createInventory(new ReportsHolder(), size, ChatColor.DARK_RED + "Reports");
-        NamespacedKey key = new NamespacedKey(plugin, "reportId");
-
-        for (int i = 0; i < Math.min(reports.size(), size); i++) {
+        int slot = 0;
+        for (int i = startIndex; i < endIndex; i++) {
             Report report = reports.get(i);
             ItemStack item = new ItemStack(Material.PAPER);
             ItemMeta meta = item.getItemMeta();
@@ -67,14 +92,100 @@ public class ViewReportsGuiCommand implements CommandExecutor {
                 lore.add(ChatColor.GRAY + "Gemeldete: " + getPlayerNameFromUUID(report.getPlayerUUID()));
                 lore.add(ChatColor.GRAY + "Grund: " + report.getReason());
                 meta.setLore(lore);
-                meta.getPersistentDataContainer().set(key, PersistentDataType.INTEGER, report.getId());
+                meta.getPersistentDataContainer().set(reportIdKey, PersistentDataType.INTEGER, report.getId());
                 item.setItemMeta(meta);
             }
-            inventory.setItem(i, item);
+            inventory.setItem(slot++, item);
         }
 
-        ((Player) sender).openInventory(inventory);
-        return true;
+        for (; slot < ITEMS_PER_PAGE; slot++) {
+            inventory.setItem(slot, null);
+        }
+
+        addNavigationItems(inventory, holder);
+    }
+
+    void refreshInventory(Player player, ReportsHolder holder, Inventory inventory) {
+        populateInventory(inventory, holder);
+        sendStatusMessage(player, holder);
+    }
+
+    private void addNavigationItems(Inventory inventory, ReportsHolder holder) {
+        int baseSlot = INVENTORY_SIZE - 9;
+        inventory.setItem(baseSlot, createNavigationItem("previous", holder.getPage() > 0, holder));
+        inventory.setItem(baseSlot + 8, createNavigationItem("next", holder.getPage() < holder.getTotalPages() - 1, holder));
+        inventory.setItem(baseSlot + 4, createPageIndicator(holder));
+        inventory.setItem(baseSlot + 5, createFilterItem(holder));
+    }
+
+    private ItemStack createNavigationItem(String type, boolean enabled, ReportsHolder holder) {
+        Material material = enabled ? Material.ARROW : Material.GRAY_STAINED_GLASS_PANE;
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            if (enabled) {
+                String displayName = type.equals("previous")
+                        ? ChatColor.GREEN + "Vorherige Seite"
+                        : ChatColor.GREEN + "Nächste Seite";
+                meta.setDisplayName(displayName);
+                meta.setLore(Arrays.asList(ChatColor.GRAY + "Aktuelle Seite: "
+                        + (holder.getPage() + 1) + "/" + holder.getTotalPages()));
+                meta.getPersistentDataContainer().set(controlKey, PersistentDataType.STRING, type);
+            } else {
+                String displayName = type.equals("previous")
+                        ? ChatColor.DARK_GRAY + "Keine vorherige Seite"
+                        : ChatColor.DARK_GRAY + "Keine nächste Seite";
+                meta.setDisplayName(displayName);
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private ItemStack createPageIndicator(ReportsHolder holder) {
+        ItemStack item = new ItemStack(Material.NAME_TAG);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GOLD + "Seite " + (holder.getPage() + 1) + " / " + holder.getTotalPages());
+            meta.setLore(Arrays.asList(ChatColor.GRAY + "Gesamt: " + holder.getTotalReports() + " Reports"));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private ItemStack createFilterItem(ReportsHolder holder) {
+        boolean onlyOpen = holder.isOnlyOpen();
+        Material material = onlyOpen ? Material.LIME_DYE : Material.GRAY_DYE;
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.AQUA + "Filter: " + (onlyOpen ? "Nur offene" : "Alle"));
+            meta.setLore(Arrays.asList(ChatColor.GRAY + "Klicke zum Umschalten"));
+            meta.getPersistentDataContainer().set(controlKey, PersistentDataType.STRING, "filter");
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private void sendStatusMessage(Player player, ReportsHolder holder) {
+        String filterMessage = holder.isOnlyOpen() ? ChatColor.GREEN + "Nur offene" : ChatColor.YELLOW + "Alle";
+        player.sendMessage(ChatColor.GOLD + "Seite " + (holder.getPage() + 1) + "/" + holder.getTotalPages()
+                + ChatColor.GRAY + " | Filter: " + filterMessage);
+    }
+
+    private List<Report> getFilteredReports(boolean onlyOpen) {
+        ReportRepository repo = plugin.getReportRepository();
+        List<Report> allReports = repo.getAllReports();
+        List<Report> filteredReports = new ArrayList<>();
+        for (Report report : allReports) {
+            if (!onlyOpen || "offen".equalsIgnoreCase(report.getStatus())) {
+                filteredReports.add(report);
+            }
+        }
+        filteredReports.sort(Comparator
+                .comparingInt((Report r) -> getStatusOrder(r.getStatus()))
+                .thenComparingInt(Report::getId));
+        return filteredReports;
     }
 
     private int getStatusOrder(String status) {
@@ -91,6 +202,53 @@ public class ViewReportsGuiCommand implements CommandExecutor {
     }
 
     public static class ReportsHolder implements InventoryHolder {
+
+        private final ViewReportsGuiCommand command;
+        private int page;
+        private int totalPages = 1;
+        private int totalReports;
+        private boolean onlyOpen;
+
+        public ReportsHolder(ViewReportsGuiCommand command) {
+            this.command = command;
+        }
+
+        public ViewReportsGuiCommand getCommand() {
+            return command;
+        }
+
+        public int getPage() {
+            return page;
+        }
+
+        public void setPage(int page) {
+            this.page = Math.max(0, page);
+        }
+
+        public int getTotalPages() {
+            return totalPages;
+        }
+
+        public void setTotalPages(int totalPages) {
+            this.totalPages = Math.max(1, totalPages);
+        }
+
+        public int getTotalReports() {
+            return totalReports;
+        }
+
+        public void setTotalReports(int totalReports) {
+            this.totalReports = Math.max(0, totalReports);
+        }
+
+        public boolean isOnlyOpen() {
+            return onlyOpen;
+        }
+
+        public void setOnlyOpen(boolean onlyOpen) {
+            this.onlyOpen = onlyOpen;
+        }
+
         @Override
         public Inventory getInventory() {
             return null;

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ViewReportsGuiListener.java
@@ -35,6 +35,10 @@ public class ViewReportsGuiListener implements Listener {
         if (!(event.getInventory().getHolder() instanceof ViewReportsGuiCommand.ReportsHolder)) {
             return;
         }
+        if (event.getClickedInventory() == null
+                || event.getClickedInventory().getHolder() != event.getInventory().getHolder()) {
+            return;
+        }
         event.setCancelled(true);
 
         ItemStack currentItem = event.getCurrentItem();
@@ -95,8 +99,6 @@ public class ViewReportsGuiListener implements Listener {
 
         if (newStatus != null) {
             repo.updateReportStatus(id, newStatus);
-            meta.setDisplayName(ChatColor.YELLOW + "ID " + id + " [" + newStatus + "]");
-            currentItem.setItemMeta(meta);
             player.sendMessage(ChatColor.GREEN + "Report " + id + " ist nun " + newStatus + ".");
             holder.getCommand().refreshInventory(player, holder, event.getInventory());
         }
@@ -105,17 +107,23 @@ public class ViewReportsGuiListener implements Listener {
     private void handleControlClick(Player player, ViewReportsGuiCommand.ReportsHolder holder,
                                      Inventory inventory, String control) {
         switch (control) {
-            case "previous":
+            case ViewReportsGuiCommand.CONTROL_PREVIOUS:
                 if (holder.getPage() > 0) {
                     holder.setPage(holder.getPage() - 1);
                     holder.getCommand().refreshInventory(player, holder, inventory);
+                } else {
+                    player.sendMessage(ChatColor.RED + "Du bist bereits auf der ersten Seite.");
                 }
                 break;
-            case "next":
-                holder.setPage(holder.getPage() + 1);
-                holder.getCommand().refreshInventory(player, holder, inventory);
+            case ViewReportsGuiCommand.CONTROL_NEXT:
+                if (holder.getPage() < holder.getTotalPages() - 1) {
+                    holder.setPage(holder.getPage() + 1);
+                    holder.getCommand().refreshInventory(player, holder, inventory);
+                } else {
+                    player.sendMessage(ChatColor.RED + "Du bist bereits auf der letzten Seite.");
+                }
                 break;
-            case "filter":
+            case ViewReportsGuiCommand.CONTROL_FILTER:
                 holder.setOnlyOpen(!holder.isOnlyOpen());
                 holder.setPage(0);
                 holder.getCommand().refreshInventory(player, holder, inventory);


### PR DESCRIPTION
## Summary
- add a paginated reports inventory that tracks page/filter state, navigation controls, and player feedback
- extend the reports GUI listener to react to navigation/filter controls and refresh metadata when statuses change

## Testing
- mvn -q -DskipTests package *(fails: dependency repository returned 403 Forbidden when resolving Paper/PlaceholderAPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b0914c588325b6d97f5271693038