### PR TITLE
Add configurable report rate limits

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -16,6 +16,8 @@ public class AkzuwoExtension extends JavaPlugin {
     private long rankPointsCheckInterval;
     private String serverName;
     private final java.util.Map<String, Integer> pendingDeleteReports = new java.util.HashMap<>();
+    private long reportCooldownSeconds;
+    private int reportMaxReports;
 
     @Override
     public void onEnable() {
@@ -32,6 +34,9 @@ public class AkzuwoExtension extends JavaPlugin {
         if (serverName == null || serverName.isBlank()) {
             serverName = "Unbekannt";
         }
+
+        reportCooldownSeconds = Math.max(1L, getConfig().getLong("report.cooldown-seconds", 300L));
+        reportMaxReports = Math.max(1, getConfig().getInt("report.max-reports-per-interval", 2));
 
         // Discord Notifier initialisieren
         discordNotifier = new DiscordNotifier(this);
@@ -151,7 +156,7 @@ public class AkzuwoExtension extends JavaPlugin {
      * Registriert alle Commands und zugehörigen TabCompleter.
      */
     private void registerCommands() {
-        getCommand("report").setExecutor(new ReportCommand(this, discordNotifier));
+        getCommand("report").setExecutor(new ReportCommand(this, discordNotifier, reportCooldownSeconds, reportMaxReports));
         getCommand("report").setTabCompleter(new ReportTabCompleter());
         getCommand("viewreports").setExecutor(new ViewReportsCommand(this));
         getCommand("viewreportsgui").setExecutor(new ViewReportsGuiCommand(this));

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/ReportCommand.java
@@ -18,12 +18,16 @@ public class ReportCommand implements CommandExecutor {
     private final AkzuwoExtension plugin;
     private final DiscordNotifier discordNotifier;
     private final Map<UUID, List<Long>> reportCooldown = new HashMap<>();
-    private static final long COOLDOWN_PERIOD = 300_000; // 5 Minuten in Millisekunden
-    private static final int MAX_REPORTS = 2;
+    private final long cooldownPeriodMillis;
+    private final long cooldownPeriodSeconds;
+    private final int maxReports;
 
-    public ReportCommand(AkzuwoExtension plugin, DiscordNotifier discordNotifier) {
+    public ReportCommand(AkzuwoExtension plugin, DiscordNotifier discordNotifier, long cooldownSeconds, int maxReports) {
         this.plugin = plugin;
         this.discordNotifier = discordNotifier;
+        this.cooldownPeriodSeconds = cooldownSeconds;
+        this.cooldownPeriodMillis = cooldownSeconds * 1000L;
+        this.maxReports = maxReports;
 
         String serverName = plugin.getServerName();
         if (discordNotifier != null) {
@@ -74,7 +78,8 @@ public class ReportCommand implements CommandExecutor {
             // Überprüfen, ob der Spieler das Report-Limit erreicht hat
             UUID reporterUUID = reporter.getUniqueId();
             if (!canReport(reporterUUID)) {
-                sender.sendMessage(ChatColor.RED + "Du kannst nur " + MAX_REPORTS + " Spieler innerhalb von 5 Minuten melden.");
+                sender.sendMessage(ChatColor.RED + "Du kannst nur " + maxReports + " Spieler innerhalb von "
+                        + cooldownPeriodSeconds + " Sekunden melden.");
                 return true;
             }
 
@@ -93,10 +98,10 @@ public class ReportCommand implements CommandExecutor {
         long currentTime = System.currentTimeMillis();
 
         // Entferne abgelaufene Timestamps
-        timestamps.removeIf(timestamp -> currentTime - timestamp > COOLDOWN_PERIOD);
+        timestamps.removeIf(timestamp -> currentTime - timestamp > cooldownPeriodMillis);
 
         reportCooldown.put(reporterUUID, timestamps);
-        return timestamps.size() < MAX_REPORTS;
+        return timestamps.size() < maxReports;
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,3 +20,8 @@ rankpointsapi:
 discord-bot-token: ""
 discord-channel-id-reports: ""
 discord-channel-id-notifications: ""
+
+# Report-Einstellungen
+report:
+  cooldown-seconds: 300 # Zeitfenster in Sekunden, in dem Meldungen begrenzt werden
+  max-reports-per-interval: 2 # Maximale Anzahl an Meldungen pro Spieler innerhalb des Zeitfensters


### PR DESCRIPTION
## Summary
- add configurable report cooldown and report limits to config.yml
- load the configured cooldown and max reports in AkzuwoExtension and pass them to ReportCommand
- honor the configured values in ReportCommand logic and player feedback

## Testing
- mvn -q -DskipTests package *(fails: dependency repository returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ba85a264832586bccad79c01498f