### PR TITLE
Add scheduled Discord report reminders

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/AkzuwoExtension.java
@@ -1,11 +1,17 @@
 package ch.ksrminecraft.akzuwoextension;
 
 import ch.ksrminecraft.akzuwoextension.commands.*;
+import ch.ksrminecraft.akzuwoextension.services.ReportReminderService;
 import ch.ksrminecraft.akzuwoextension.utils.*;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.sql.SQLException;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 public class AkzuwoExtension extends JavaPlugin {
     private PrefixedLogger logger;
@@ -18,6 +24,8 @@ public class AkzuwoExtension extends JavaPlugin {
     private final java.util.Map<String, Integer> pendingDeleteReports = new java.util.HashMap<>();
     private long reportCooldownSeconds;
     private int reportMaxReports;
+    private ReportReminderService reportReminderService;
+    private int reminderTaskId = -1;
 
     @Override
     public void onEnable() {
@@ -115,12 +123,20 @@ public class AkzuwoExtension extends JavaPlugin {
         // Listener registrieren
         getServer().getPluginManager().registerEvents(new ViewReportsGuiListener(this), this);
 
+        // Reminder Scheduler initialisieren
+        setupReportReminderScheduler();
+
         // Nach Updates suchen
         new UpdateChecker(this).checkForUpdates();
     }
 
     @Override
     public void onDisable() {
+        if (reminderTaskId != -1) {
+            Bukkit.getScheduler().cancelTask(reminderTaskId);
+            reminderTaskId = -1;
+        }
+
         // Datenbankverbindung schließen
         try {
             if (databaseManager != null) {
@@ -150,6 +166,77 @@ public class AkzuwoExtension extends JavaPlugin {
             }
         }
 
+        reportReminderService = null;
+
+    }
+
+    private void setupReportReminderScheduler() {
+        if (discordNotifier == null) {
+            logger.warning("Report-Reminder konnte nicht gestartet werden, Discord-Notifier ist nicht verfügbar.");
+            return;
+        }
+
+        long longRunningHours = Math.max(1L, getConfig().getLong("reminders.long-running-threshold-hours", 48L));
+        int escalateOpenCount = Math.max(0, getConfig().getInt("reminders.escalate-open-count", 10));
+        reportReminderService = new ReportReminderService(this, reportRepository, discordNotifier, longRunningHours, escalateOpenCount);
+
+        if (!getConfig().getBoolean("reminders.enabled", false)) {
+            logger.info("Report-Reminder ist in der Konfiguration deaktiviert.");
+            return;
+        }
+
+        long intervalMinutes = Math.max(1L, getConfig().getLong("reminders.interval-minutes", 60L));
+        String sendTime = getConfig().getString("reminders.daily-send-time");
+
+        long periodTicks = intervalMinutes * 60L * 20L;
+        long initialDelayTicks = 20L; // Default 1 Sekunde
+
+        if (sendTime != null && !sendTime.isBlank()) {
+            try {
+                LocalTime target = LocalTime.parse(sendTime.trim());
+                ZoneId zoneId = ZoneId.systemDefault();
+                ZonedDateTime now = ZonedDateTime.now(zoneId);
+                ZonedDateTime nextRun = now.with(target);
+                if (!now.toLocalTime().isBefore(target)) {
+                    nextRun = nextRun.plusDays(1);
+                }
+                Duration untilNext = Duration.between(now, nextRun);
+                long delaySeconds = Math.max(1L, untilNext.getSeconds());
+                initialDelayTicks = delaySeconds * 20L;
+                periodTicks = 20L * 60L * 60L * 24L; // Ein Tag
+            } catch (DateTimeParseException ex) {
+                logger.warning("Ungültiges Format für reminders.daily-send-time. Erwartet wird HH:mm. Es wird das Intervall verwendet.");
+            }
+        }
+
+        if (periodTicks <= 0) {
+            periodTicks = 20L * 60L; // Fallback auf eine Minute
+        }
+
+        reminderTaskId = Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> {
+            try {
+                reportReminderService.runReminder();
+            } catch (Exception exception) {
+                logger.severe("Fehler beim Ausführen des Report-Reminders: " + exception.getMessage());
+            }
+        }, initialDelayTicks, periodTicks).getTaskId();
+
+        logger.info("Report-Reminder gestartet (Periode: " + (periodTicks / (20L * 60L)) + " Minuten).");
+    }
+
+    public boolean triggerReportReminder() {
+        if (reportReminderService == null) {
+            return false;
+        }
+
+        Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+            try {
+                reportReminderService.runReminder();
+            } catch (Exception exception) {
+                logger.severe("Fehler beim manuellen Ausführen des Report-Reminders: " + exception.getMessage());
+            }
+        });
+        return true;
     }
 
     /**

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/commands/AkzuwoExtensionCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/commands/AkzuwoExtensionCommand.java
@@ -17,25 +17,41 @@ public class AkzuwoExtensionCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (args.length == 1 && args[0].equalsIgnoreCase("confirm")) {
-            Integer reportId = plugin.pollPendingDelete(sender.getName());
-            if (reportId == null) {
-                sender.sendMessage(ChatColor.RED + "Es gibt keinen Löschvorgang zu bestätigen.");
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("confirm")) {
+                Integer reportId = plugin.pollPendingDelete(sender.getName());
+                if (reportId == null) {
+                    sender.sendMessage(ChatColor.RED + "Es gibt keinen Löschvorgang zu bestätigen.");
+                    return true;
+                }
+
+                Report report = plugin.getReportRepository().getReportById(reportId);
+                if (report == null) {
+                    sender.sendMessage(ChatColor.RED + "Report mit der ID " + reportId + " wurde nicht gefunden.");
+                    return true;
+                }
+
+                plugin.getReportRepository().deleteReportById(reportId);
+                sender.sendMessage(ChatColor.GREEN + "Report mit der ID " + reportId + " wurde erfolgreich gelöscht.");
                 return true;
             }
 
-            Report report = plugin.getReportRepository().getReportById(reportId);
-            if (report == null) {
-                sender.sendMessage(ChatColor.RED + "Report mit der ID " + reportId + " wurde nicht gefunden.");
+            if (args[0].equalsIgnoreCase("remind")) {
+                if (!sender.hasPermission("akzuwoextension.staff")) {
+                    sender.sendMessage(ChatColor.RED + "Keine Berechtigung.");
+                    return true;
+                }
+
+                if (plugin.triggerReportReminder()) {
+                    sender.sendMessage(ChatColor.GREEN + "Report-Reminder wurde an Discord gesendet.");
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Report-Reminder ist aktuell nicht verfügbar.");
+                }
                 return true;
             }
-
-            plugin.getReportRepository().deleteReportById(reportId);
-            sender.sendMessage(ChatColor.GREEN + "Report mit der ID " + reportId + " wurde erfolgreich gelöscht.");
-            return true;
         }
 
-        sender.sendMessage(ChatColor.RED + "Verwendung: /akzuwoextension confirm");
+        sender.sendMessage(ChatColor.RED + "Verwendung: /akzuwoextension confirm | remind");
         return true;
     }
 }

--- a/src/main/java/ch/ksrminecraft/akzuwoextension/services/ReportReminderService.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoextension/services/ReportReminderService.java
@@ -1,0 +1,190 @@
+package ch.ksrminecraft.akzuwoextension.services;
+
+import ch.ksrminecraft.akzuwoextension.AkzuwoExtension;
+import ch.ksrminecraft.akzuwoextension.utils.DiscordNotifier;
+import ch.ksrminecraft.akzuwoextension.utils.PrefixedLogger;
+import ch.ksrminecraft.akzuwoextension.utils.Report;
+import ch.ksrminecraft.akzuwoextension.utils.ReportRepository;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Service-Klasse, die zyklisch Erinnerungen über offene Reports an Discord sendet.
+ */
+public class ReportReminderService {
+
+    private static final int MAX_DETAILS = 5;
+    private static final Comparator<Report> REPORT_TIMESTAMP_COMPARATOR =
+            Comparator.comparing(Report::getTimestamp, Comparator.nullsLast(Comparator.naturalOrder()));
+
+    private final AkzuwoExtension plugin;
+    private final ReportRepository reportRepository;
+    private final DiscordNotifier discordNotifier;
+    private final PrefixedLogger logger;
+    private final long longRunningThresholdHours;
+    private final int escalateOpenCount;
+
+    public ReportReminderService(AkzuwoExtension plugin,
+                                 ReportRepository reportRepository,
+                                 DiscordNotifier discordNotifier,
+                                 long longRunningThresholdHours,
+                                 int escalateOpenCount) {
+        this.plugin = plugin;
+        this.reportRepository = reportRepository;
+        this.discordNotifier = discordNotifier;
+        this.logger = plugin.getPrefixedLogger();
+        this.longRunningThresholdHours = Math.max(1L, longRunningThresholdHours);
+        this.escalateOpenCount = Math.max(0, escalateOpenCount);
+    }
+
+    /**
+     * Führt den Reminderlauf aus und informiert den hinterlegten Discord-Channel.
+     */
+    public void runReminder() {
+        if (discordNotifier == null) {
+            logger.fine("Report-Reminder übersprungen, da kein Discord-Notifier initialisiert wurde.");
+            return;
+        }
+
+        List<Report> reports = new ArrayList<>(reportRepository.getAllReports());
+        Instant now = Instant.now();
+
+        List<Report> openReports = reports.stream()
+                .filter(report -> report.getStatus() != null && report.getStatus().equalsIgnoreCase("open"))
+                .sorted(REPORT_TIMESTAMP_COMPARATOR)
+                .collect(Collectors.toList());
+
+        List<Report> longRunningReports = openReports.stream()
+                .filter(report -> isLongRunning(report, now))
+                .sorted(REPORT_TIMESTAMP_COMPARATOR)
+                .collect(Collectors.toList());
+
+        String message = buildMessage(openReports, longRunningReports, now);
+        discordNotifier.sendReportNotification(message);
+        logger.fine("Report-Reminder versendet (" + openReports.size() + " offene Reports).");
+    }
+
+    private boolean isLongRunning(Report report, Instant now) {
+        Timestamp timestamp = report.getTimestamp();
+        if (timestamp == null) {
+            return false;
+        }
+
+        Instant created = timestamp.toInstant();
+        if (created.isAfter(now)) {
+            return false;
+        }
+
+        Duration duration = Duration.between(created, now);
+        return duration.toHours() >= longRunningThresholdHours;
+    }
+
+    private String buildMessage(List<Report> openReports, List<Report> longRunningReports, Instant now) {
+        long totalMinutes = 0;
+        Duration longestAge = Duration.ZERO;
+
+        for (Report report : openReports) {
+            Timestamp timestamp = report.getTimestamp();
+            if (timestamp == null) {
+                continue;
+            }
+            Instant created = timestamp.toInstant();
+            if (created.isAfter(now)) {
+                continue;
+            }
+            Duration age = Duration.between(created, now);
+            totalMinutes += Math.max(0, age.toMinutes());
+            if (age.compareTo(longestAge) > 0) {
+                longestAge = age;
+            }
+        }
+
+        double averageHours = openReports.isEmpty()
+                ? 0
+                : (double) totalMinutes / openReports.size() / 60.0;
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("**Report-Reminder - ")
+                .append(plugin.getServerName())
+                .append("**\n");
+        builder.append("Offene Reports: ")
+                .append(openReports.size())
+                .append(" | Durchschnittliches Alter: ")
+                .append(String.format(Locale.GERMAN, "%.1f", averageHours))
+                .append("h\n");
+
+        if (!longestAge.isZero()) {
+            builder.append("Ältester Report: ")
+                    .append(formatDuration(longestAge))
+                    .append(" offen\n");
+        }
+
+        if (!longRunningReports.isEmpty()) {
+            builder.append("\n**Langlaufende Reports (>")
+                    .append(longRunningThresholdHours)
+                    .append("h)**\n");
+
+            int details = Math.min(MAX_DETAILS, longRunningReports.size());
+            for (int i = 0; i < details; i++) {
+                Report report = longRunningReports.get(i);
+                Timestamp timestamp = report.getTimestamp();
+                Duration age = Duration.ZERO;
+                if (timestamp != null) {
+                    Instant created = timestamp.toInstant();
+                    if (!created.isAfter(now)) {
+                        age = Duration.between(created, now);
+                    }
+                }
+
+                builder.append("- #")
+                        .append(report.getId())
+                        .append(" | Spieler: ")
+                        .append(report.getPlayerUUID() != null ? report.getPlayerUUID() : "unbekannt")
+                        .append(" | Grund: ")
+                        .append(report.getReason() != null ? report.getReason() : "-")
+                        .append(" | Dauer: ")
+                        .append(formatDuration(age))
+                        .append("\n");
+            }
+
+            if (longRunningReports.size() > MAX_DETAILS) {
+                builder.append("… und ")
+                        .append(longRunningReports.size() - MAX_DETAILS)
+                        .append(" weitere.\n");
+            }
+        }
+
+        if (escalateOpenCount > 0 && openReports.size() >= escalateOpenCount) {
+            builder.append("\n:warning: Eskalation: ")
+                    .append(openReports.size())
+                    .append(" offene Reports überschreiten den Schwellwert von ")
+                    .append(escalateOpenCount)
+                    .append(".\n");
+        }
+
+        return builder.toString();
+    }
+
+    private String formatDuration(Duration duration) {
+        long days = duration.toDays();
+        long hours = duration.minusDays(days).toHours();
+        long minutes = duration.minusDays(days).minusHours(hours).toMinutes();
+
+        StringBuilder builder = new StringBuilder();
+        if (days > 0) {
+            builder.append(days).append("d ");
+        }
+        if (hours > 0 || days > 0) {
+            builder.append(hours).append("h ");
+        }
+        builder.append(minutes).append("m");
+        return builder.toString().trim();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
+# Allgemeine Einstellungen
+default-server-name: "Akzuwo" # Name des Servers, der in Discord-Benachrichtigungen erscheint
+
 # Datenbankkonfiguration für das Report-System
 database:
   enabled: false #if set to false the plugin will create a local json file to log reports
@@ -20,6 +23,14 @@ rankpointsapi:
 discord-bot-token: ""
 discord-channel-id-reports: ""
 discord-channel-id-notifications: ""
+
+# Reminder-Einstellungen für offene Reports
+reminders:
+  enabled: false # Aktiviert den automatischen Versand von Erinnerungen
+  interval-minutes: 60 # Intervall in Minuten für wiederkehrende Erinnerungen (wenn keine Versandzeit gesetzt ist)
+  daily-send-time: "" # Optional: Uhrzeit im HH:mm-Format für tägliche Erinnerungen (überschreibt interval-minutes)
+  long-running-threshold-hours: 48 # Ab wie vielen Stunden offene Reports als langlaufend gelten
+  escalate-open-count: 10 # Ab wie vielen offenen Reports eine Eskalationswarnung angefügt wird (0 zum Deaktivieren)
 
 # Report-Einstellungen
 report:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,8 +19,8 @@ commands:
     description: Delete a report by ID.
     usage: /deletereport <id>
   akzuwoextension:
-    description: Base command for confirmations.
-    usage: /akzuwoextension confirm
+    description: Base command for Bestätigungen und Reminder.
+    usage: /akzuwoextension confirm|remind
 
 tutorialcommand: true
 


### PR DESCRIPTION
## Summary
- add configurable reminder options for Discord notifications in the default configuration
- schedule a ReportReminderService on plugin startup and expose a manual `/akzuwoextension remind` command
- compile open and long-running report statistics for Discord and include server context in reminders

## Testing
- `mvn -q -DskipTests package` *(fails: dependency download blocked with HTTP 403 from papermc repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d9be1b6bcc83259935cd5de06608bd